### PR TITLE
marketplace/chore: add contract method FinalListing in marketplace chore

### DIFF
--- a/marketplace/chore.go
+++ b/marketplace/chore.go
@@ -76,7 +76,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 			_, err = transfer.FinalListing(ctx, casper.FinalListingRequest{
 				PublicKey:          pair.PublicKey(),
 				ChainName:          "casper-test",
-				StandardPayment:    int64(lot.CurrentPrice.BitLen()),
+				StandardPayment:    10000000000,
 				MarketContractHash: chore.marketplace.config.MarketContractAddress,
 				NFTContractHash:    fmt.Sprintf("%s%s", chore.marketplace.config.NFTContractPrefix, chore.marketplace.config.NFTContractAddress),
 				TokenID:            tokenID.String(),

--- a/marketplace/chore.go
+++ b/marketplace/chore.go
@@ -5,11 +5,16 @@ package marketplace
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 
 	"github.com/BoostyLabs/thelooper"
+	casper_ed25519 "github.com/casper-ecosystem/casper-golang-sdk/keypair/ed25519"
 	"github.com/zeebo/errs"
 
 	"ultimatedivision/cards"
+	"ultimatedivision/internal/contract/casper"
+	contract "ultimatedivision/pkg/contractcasper"
 )
 
 var (
@@ -28,8 +33,8 @@ type Chore struct {
 // NewChore instantiates Chore.
 func NewChore(config Config, marketplace *Service) *Chore {
 	return &Chore{
-		marketplace: marketplace,
 		Loop:        thelooper.NewLoop(config.LotRenewalInterval),
+		marketplace: marketplace,
 	}
 }
 
@@ -43,6 +48,43 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 
 		// TODO: the transaction may be required for all operations.
 		for _, lot := range lots {
+			tokenID, err := chore.marketplace.GetNFTTokenIDbyCardID(ctx, lot.CardID)
+			if err != nil {
+				return ChoreError.Wrap(err)
+			}
+
+			privateAccountKey := chore.marketplace.config.ContractOwnerPrivateKey
+			privateAccountKeyBytes, err := hex.DecodeString(privateAccountKey)
+			if err != nil {
+				return ChoreError.Wrap(err)
+			}
+
+			publicAccountKey := chore.marketplace.config.ContractOwnerPublicKey
+			publicAccountKeyBytes, err := hex.DecodeString(publicAccountKey)
+			if err != nil {
+				return ChoreError.Wrap(err)
+			}
+
+			pair := casper_ed25519.ParseKeyPair(publicAccountKeyBytes, privateAccountKeyBytes)
+
+			casperClient := contract.New(chore.marketplace.config.RPCNodeAddress)
+			transfer := casper.NewTransfer(casperClient, func(b []byte) ([]byte, error) {
+				casperSignature := pair.Sign(b)
+				return casperSignature.SignatureData, nil
+			})
+
+			_, err = transfer.FinalListing(ctx, casper.FinalListingRequest{
+				PublicKey:          pair.PublicKey(),
+				ChainName:          "casper-test",
+				StandardPayment:    int64(lot.CurrentPrice.BitLen()),
+				MarketContractHash: chore.marketplace.config.MarketContractAddress,
+				NFTContractHash:    fmt.Sprintf("%s%s", chore.marketplace.config.NFTContractPrefix, chore.marketplace.config.NFTContractAddress),
+				TokenID:            tokenID.String(),
+			})
+			if err != nil {
+				return ChoreError.Wrap(err)
+			}
+
 			if lot.CurrentPrice.BitLen() != 0 {
 				// TODO: unhold old user's money.
 
@@ -62,7 +104,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 				continue
 			}
 
-			err := chore.marketplace.UpdateStatusLot(ctx, lot.CardID, StatusExpired)
+			err = chore.marketplace.UpdateStatusLot(ctx, lot.CardID, StatusExpired)
 			if err != nil {
 				return ChoreError.Wrap(err)
 			}

--- a/marketplace/marketplace.go
+++ b/marketplace/marketplace.go
@@ -113,6 +113,9 @@ type Config struct {
 	NFTContractPrefix            string `json:"nftContractPrefix"`
 
 	TokenAmountForApproving int64 `json:"tokenAmountForApproving"`
+
+	ContractOwnerPrivateKey string `json:"contractOwnerPrivateKey"`
+	ContractOwnerPublicKey  string `json:"contractOwnerPublicKey"`
 }
 
 // CreateLot entity that contains the values required to create the lot.

--- a/marketplace/service.go
+++ b/marketplace/service.go
@@ -119,6 +119,12 @@ func (service *Service) GetCurrentPriceByCardID(ctx context.Context, cardID uuid
 	return currentPrice, ErrMarketplace.Wrap(err)
 }
 
+// GetNFTTokenIDbyCardID returns nft token id by card id from database.
+func (service *Service) GetNFTTokenIDbyCardID(ctx context.Context, cardID uuid.UUID) (uuid.UUID, error) {
+	tokenID, err := service.nfts.GetNFTTokenIDbyCardID(ctx, cardID)
+	return tokenID, ErrMarketplace.Wrap(err)
+}
+
 // GetNFTByCardID returns nft by card id from DB.
 func (service *Service) GetNFTByCardID(ctx context.Context, id uuid.UUID) (nfts.NFT, error) {
 	nft, err := service.nfts.GetNFTByCardID(ctx, id)


### PR DESCRIPTION
after merging this PR need add 2 fields in the config file:

contractOwnerPrivateKey
contractOwnerPublicKey
"marketplace": {
"lotRenewalInterval": 5000000000,
"cursor": {
"limit": 10,
"page": 1
},
"rpcNodeAddress": "http://116.202.169.210:7777/rpc",
"nftContractAddress": "05560ca94e73f35c5b9b8a0f8b66e56238169e60ae421fb7b71c7ac3c6c744e2",
"marketContractAddress": "feed638f60f5a2840656d86e0e51dc62c092e79d980ba8dc281387dbb8f80c42",
"tokenContractAddress": "5aed0843516b06e4cbf56b1085c4af37035f2c9c1f18d7b0ffd7bbe96f91a3e0",
"marketContractPackageAddress": "701ed1a382367a6016f3b389f75177030fd583c5b8838b4c04e92da6b4a11928",
"nftApprovePrefix": "contract-package-wasm",
"createListingPrefix": "contract-",
"tokenAmountForApproving": 10000,
"contractOwnerPrivateKey": "4f0ffa6c3925d02127a9e9213c7c21215dbc288e0ee61770e6adf7752324c282",
"contractOwnerPublicKey": "ad794c8f3da55845a5422506b4bd01ed1ae4e57378a82216d25d7351854b563d"
},